### PR TITLE
Reduce the SAX parser symbol hash table size from 65536 entries to 1024

### DIFF
--- a/sax/sax-symbols.ads
+++ b/sax/sax-symbols.ads
@@ -91,7 +91,7 @@ private
       Hash          => Hash,
       Equal         => Key_Equal);
 
-   Hash_Num : constant := 2**16;
+   Hash_Num : constant := 2**10;
    --  Number of headers in the hash table
 
    type Hash_Type is range 0 .. Hash_Num - 1;


### PR DESCRIPTION
The SAX parser is using a hash table size of 65536 entries which represents a 2 Mb area.
This creates a (minor) memory usage issue but also a performance issue.  Each time
an XML parser is created, the hash table is initialized and we get a 2Mb allocation
as well as clearing of the hash table which fills up the cache for nothing. This cache
filling creates performance degradation. By reducing the hash table size to 1024,
the hash table is reduced to 32kb hence leaving less pressure on the cache.

See https://blog.vacs.fr/vacs/blogs/post.html?post=2013/03/02/Optimization-with-Valgrind-Massif-and-Cachegrind for a more detailed explanation of the issue.  The post is old but the problem is still present and visible with the current version.
