### PR TITLE
Enable Validation_Feature in domschemaexample.adb

### DIFF
--- a/docs/dom/domschemaexample.adb
+++ b/docs/dom/domschemaexample.adb
@@ -15,7 +15,7 @@ begin
    Set_Public_Id (Input, "Preferences file");
    Open ("pref_with_xsd.xml", Input);
 
-   Set_Feature (Reader, Validation_Feature, False);
+   Set_Feature (Reader, Validation_Feature, True);
 
    Parse (Reader, Input);
    Close (Input);


### PR DESCRIPTION
I believe the ``Validation_Feature`` should be set to ``True`` in this example that demonstrates how to do validation in combination with DOM-based XML processing.