### PR TITLE
Initial support for xml standalone feature

### DIFF
--- a/dom/dom-core-nodes.adb
+++ b/dom/dom-core-nodes.adb
@@ -1437,9 +1437,20 @@ package body DOM.Core.Nodes is
                if Print_XML_Declaration then
                   String'Write
                     (Stream, Write_Bom (Encoding.Encoding_Scheme.BOM));
-                  Put
-                    (Stream, "<?xml version=""1.0"" encoding="""
-                     & Encoding.Name.all & """?>", Encoding);
+                  if N.Implementation.Alone then
+                     Put
+                       (Stream, "<?xml version=""1.0"" encoding="""
+                        & Encoding.Name.all
+                        & """ standalone="""
+                        & "yes"
+                        & """ ?>", Encoding);
+                  else
+                     Put
+                       (Stream, "<?xml version=""1.0"" encoding="""
+                        & Encoding.Name.all
+                        & """ standalone="""
+                        & "no" & """ ?>", Encoding);
+                  end if;
                   Print_String (Stream, "" & ASCII.LF, EOL_Sequence, Encoding);
                end if;
                Recursive_Print (N.Doc_Children);

--- a/dom/dom-core.adb
+++ b/dom/dom-core.adb
@@ -260,4 +260,23 @@ package body DOM.Core is
       end if;
    end Document_Remove_Id;
 
+   --------------------------------------
+   -- Get & set the Standalone prolog ---
+   --------------------------------------
+
+   function Is_Standalone
+     (Implementation : DOM_Implementation)
+      return Boolean is
+   begin
+      return Implementation.Alone;
+   end Is_Standalone;
+
+   procedure Standalone
+     (Implementation : in out DOM_Implementation;
+      Alone          :        Boolean) is
+   begin
+      Implementation.Alone := Alone;
+   end Standalone;
+
+
 end DOM.Core;

--- a/dom/dom-core.ads
+++ b/dom/dom-core.ads
@@ -147,6 +147,14 @@ package DOM.Core is
    procedure Set_Node_List_Growth_Factor (Factor : Float);
    --  Set the growth factor, see Default_Node_List_Growth_Factor
 
+   function Is_Standalone
+     (Implementation : DOM_Implementation)
+      return Boolean;
+
+   procedure Standalone
+     (Implementation : in out DOM_Implementation;
+      Alone          :            Boolean);
+
    --------------------
    -- Dom exceptions --
    --------------------
@@ -206,7 +214,9 @@ package DOM.Core is
 
 private
 
-   type DOM_Implementation is null record;
+   type DOM_Implementation is record
+      Alone : Boolean;
+   end record;
 
    type Node_Array is array (Natural range <>) of Node;
    type Node_Array_Access is access Node_Array;


### PR DESCRIPTION
The xml header allows for standalone=yes, the default being no.

This patch allows the DOM to specify the alternate. This only applies to the DOM write. If this is acceptable, I'll look to get the read fixed.

I placed the holder into DOM_Implementation and is therefore no longer a null record. This seems like the best place to put it. I would also have thought that the encoding scheme, utf-whatever, would have been placed there.