### PR TITLE
Improve punctuation in documentation

### DIFF
--- a/docs/dom.rst
+++ b/docs/dom.rst
@@ -6,7 +6,7 @@ The DOM module
 
 DOM is another standard associated with XML, in which the XML stream is
 represented as a tree in memory. This tree can be manipulated at will, to add
-new nodes, remove existing nodes, change attributes,...
+new nodes, remove existing nodes, change attributes…
 
 Since it contains the whole XML information, it can then in turn be dumped to a
 stream.
@@ -26,7 +26,7 @@ adds namespaces over the first revision. The third revision is not supported at
 this point, and it adds support for loading and saving XML streams in a
 standardized fashion.
 
-Although it doesn't support DOM 3.0, XML/Ada provides subprograms for doing
+Although it doesn’t support DOM 3.0, XML/Ada provides subprograms for doing
 similar things.
 
 Only the Core module of the DOM standard is currently implemented, other
@@ -103,7 +103,7 @@ fully.
 
 One important note however is related to the use of strings. Various
 subprograms allow you to set the textual content of a node, modify its
-attributes,.... Such subprograms take a Byte_Sequence as a parameter.
+attributes…  Such subprograms take a Byte_Sequence as a parameter.
 
 This Byte_Sequence must always be encoded in the encoding defined in the
 package `Sax.Encoding` (as described earlier, changing this package requires

--- a/docs/input.rst
+++ b/docs/input.rst
@@ -11,8 +11,8 @@ access files and manipulate standard Ada strings.
 A top-level tagged type is provided that must be extended for the various
 streams. It is assumed that the pointer to the current character in the stream
 can only go forward, and never backward. As a result, it is possible to
-implement this package for sockets or other streams where it isn't even
-possible to go backward. This also means that one doesn't have to provide
+implement this package for sockets or other streams where it isn’t even
+possible to go backward. This also means that one doesn’t have to provide
 buffers in such cases, and thus that it is possible to provide memory-efficient
 readers.
 
@@ -28,7 +28,7 @@ They all provide the following primitive operations:
 
 `Open`
 
-  Although this operation isn't exactly overridden, since its parameters
+  Although this operation isn’t exactly overridden, since its parameters
   depend on the type of stream you want to read from, it is nice to
   use a standard name for this constructor.
 
@@ -37,7 +37,7 @@ They all provide the following primitive operations:
   is no longer possible to read from the stream afterwards.
 
 `Next_Char`
-  Return the next Unicode character in the stream. Note this character doesn't
+  Return the next Unicode character in the stream. Note this character doesn’t
   have to be associated specifically with a single byte, but that it depends on
   the encoding chosen for the stream (see the unicode module documentation for
   more information).
@@ -58,13 +58,13 @@ detect the encoding to use for a file, based on a header read directly from the
 file.
 
 Based on the first four bytes of the stream (assuming this is valid XML), they
-will automatically detect whether the file was encoded as Utf8, Utf16,... If
+will automatically detect whether the file was encoded as Utf8, Utf16…  If
 you are writing your own input streams, consider adding this automatic
 detection as well.
 
 However, it is always possible to override the default through a call to
-`Set_Encoding`. This allows you to specify both the character set (Latin1, ...)
-and the character encoding scheme (Utf8,...).
+`Set_Encoding`. This allows you to specify both the character set (Latin1…)
+and the character encoding scheme (Utf8…).
 
 The user is also encouraged to set the identifiers for the stream they are
 parsing, through calls to `Set_System_Id` and `Set_Public_Id`. These are used

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -15,6 +15,6 @@ standards related to XML.
 We have tried to follow as closely as possible the XML standard, so that you
 can easily analyze and reuse languages produced for other languages.
 
-This document isn't a tutorial on what XML is, nor on the various standards
+This document isn’t a tutorial on what XML is, nor on the various standards
 like DOM and SAX. Although we will try and give a few examples, we refer the
 reader to the standards themselves, which are all easily readable.

--- a/docs/sax.rst
+++ b/docs/sax.rst
@@ -13,7 +13,7 @@ manipulate XML files is to represent them in a tree and manipulate it through
 the DOM interface (see next chapter).
 
 The **Simple API for XML** is another method that can be used for parsing.  It
-is based on a callbacks mechanism, and doesn't store any data in memory (unless
+is based on a callbacks mechanism, and doesn’t store any data in memory (unless
 of course you choose to do so in your callbacks). It can thus be more efficient
 to use SAX than DOM for some specialized algorithms.  In fact, this whole Ada
 XML library is based on such a SAX parser, then creates the DOM tree through
@@ -67,7 +67,7 @@ The following events would then be generated when this file is parsed::
   
 
 As you can see, there is a number of events even for a very small file.
-However, you can easily choose to ignore the events you don't care
+However, you can easily choose to ignore the events you don’t care
 about, for instance the ones related to namespace handling.
 
 Examples
@@ -75,7 +75,7 @@ Examples
 
 There are several cases where using a SAX parser rather than a DOM
 parser would make sense. Here are some examples, although obviously
-this doesn't include all the possible cases. These examples are taken
+this doesn’t include all the possible cases. These examples are taken
 from the documentation of libxml, a GPL C toolkit for manipulating XML files.
 
 * Using XML files as a database
@@ -183,7 +183,7 @@ here is a list of the most frequently used callbacks, that you will probably
 need to override in most of your applications.
 
 *Start_Document*
-  This callback, that doesn't receive any parameter, is called once, just
+  This callback, that doesn’t receive any parameter, is called once, just
   before parsing the document. It should generally be used to initialize
   internal data needed later on. It is also guaranteed to be called only once
   per input stream.
@@ -203,7 +203,7 @@ need to override in most of your applications.
 *End_Element*
   This is the opposite of the previous callback, and will be called once per
   element. Calls to `Start_Element` and `End_Element` are guaranteed
-  to be properly nested (ie you can't see the end of an element before seeing
+  to be properly nested (ie you can’t see the end of an element before seeing
   the end of all its nested children.
 
 *Characters and Ignore_Whitespace*
@@ -235,7 +235,7 @@ The XML file is the following::
   </preferences>
   
 
-This is a very simple example which doesn't use namespaces, and has a very
+This is a very simple example which doesn’t use namespaces, and has a very
 limited nesting of nodes. However, that should help demonstrate the basics of
 using SAX.
 
@@ -284,7 +284,7 @@ There are two steps in setting up an XML parser:
 
   The behavior of an XML parser can be changed in several ways by activating or
   deactivating some features. In the example above, we have specified that the
-  XML document doesn't contain namespaces, and that we do not intend to
+  XML document doesn’t contain namespaces, and that we do not intend to
   validate the XML file against a grammar.
 
 Once the two steps above are done, we can simply call the procedure `Parse` to
@@ -393,7 +393,7 @@ Understanding SAX error messages
 ================================
 
 XML/Ada error messages try to be as explicit as possible. They are not,
-however, meant to be understood by someone who doesn't know XML.
+however, meant to be understood by someone who doesn’t know XML.
 
 In addition to the location of the error (line and column in the file),
 they might contain one of the following abbreviations:
@@ -413,7 +413,7 @@ they might contain one of the following abbreviations:
 
   This abbreviation indicates that the error message is related to an
   unsatisfied validity-constraint, as defined in the XML standard. The XML
-  document is well-formed, although it doesn't match the semantic rules
+  document is well-formed, although it doesn’t match the semantic rules
   that the grammar defines. For instance, if you are trying to validate an
   XML document against a DTD, the document must contain a DTD that defines the
   name of the root element.

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -14,7 +14,7 @@ XML files:
 
   This is a basic step where we ensure that XML tags are correctly nested, that
   closing tags have the same names as the matching opening tags, that attribute
-  values are quoted,.... This corresponds to a syntactic parser in a compiler.
+  values are quoted…  This corresponds to a syntactic parser in a compiler.
 
   This step does not depend on the application domain. One file that is
   well-formed will always be so, no matter in what context you use it.
@@ -27,14 +27,14 @@ XML files:
 
   This is the phase in which the application needs to check whether a given XML
   file has all its required attributes, whether the children of an XML tag are
-  the expected ones, whether the type of the attributes is valid,....
+  the expected ones, whether the type of the attributes is valid…
 
 * Use the XML file in the application.
 
   This is done through the already-described SAX or DOM parsers
 
 The first phase is mandatory, and necessarily enforced by XML/Ada. You will not
-be able to access the contents of the XML file if it isn't well-formed.
+be able to access the contents of the XML file if it isn’t well-formed.
 
 The second phase is provided by the Schema module in XML/Ada. Although such
 constraints can be checked at the application level, with ad hoc code, it is
@@ -51,7 +51,7 @@ satisfy in order to be considered as valid.
   The Document Type Description is the original way to do this. They come
   directly from the ancestor of XML, SGML. All XML parsers must parse the DTD,
   and report events if the user is using SAX. However, not all parsers are able
-  to validate the document against a DTD (XML/Ada doesn't).
+  to validate the document against a DTD (XML/Ada doesn’t).
 
   Their use tends to greatly diminish. Among their limitations are a limited
   capability to express constraints on the order of tag children, the fact that
@@ -63,7 +63,7 @@ satisfy in order to be considered as valid.
   The XML schemas are replacing the DTDs. They are written in XML, and provide
   an extensive capability to describe what the XML document should look like.
   In fact, almost all Ada types can be described in an XML schema, including
-  range constraints, arrays, records, type inheritance, abstract types,....
+  range constraints, arrays, records, type inheritance, abstract types…
 
   It is for instance possible to indicate that the value of a preference, in
   our example, must be a string of length 6. Any other length will result in a
@@ -84,8 +84,8 @@ a tutorial (`http://www.w3.org/TR/xmlschema-0/
 
 The typical extension for a schema file is :file:`.xsd`.
 
-A schema file must be a valid XML file, and thus start with the usual `<?xml
-version="1.0" ?>` line. The root node must be named `schema`, and belong to the
+A schema file must be a valid XML file, and thus start with the usual
+``<?xml version="1.0" ?>`` line. The root node must be named `schema`, and belong to the
 namespace (`http://www.w3.org/2001/XMLSchema/
 <http://www.w3.org/2001/XMLSchema/>`_). The handling of namespaces is fairly
 powerful, but also complex. A given XML document might have nodes belonging to
@@ -114,13 +114,12 @@ The contents of the element is then defined in one of two ways:
 
   Schemas come with a number of predefined simple types. A simple type is
   such that an element of that type accepts no child node, and that its
-  contents must satisfy additional constraints (be an integer, a date,
-  ...).
+  contents must satisfy additional constraints (be an integer, a date…).
 
   Among the predefined simple types (which are all defined in the namespace
   `http://www.w3.org/2001/XMLSchema/ <http://www.w3.org/2001/XMLSchema/>`_),
   one can find: `string`, `integer`, `byte`, `date`, `time`, `dateTime`,
-  `boolean`,...
+  `boolean`…
 
   If no additional constraint should be enforced on this simple type when
   applied to the element, the type of the element is given through a `type`
@@ -337,7 +336,7 @@ validating a file.
 
     This attribute is a list of strings, alternatively the prefix of
     a namespace and the name of an xsd file to use for that
-    namespace. For instance, `"ns1 file1.xsd ns2 file2.xsd"`.
+    namespace. For instance, ``"ns1 file1.xsd ns2 file2.xsd"``.
 
   When it encounters any of these two attributes, XML/Ada will
   automatically parse the corresponding schema files, and use the result
@@ -368,7 +367,7 @@ using SAX itself. Instead of inheriting from `Sax.Readers.Reader`, your tagged
 type must inherit from `Schema.Readers.Validating_Reader`.
 
 As usual, you can still override the predefined primitive operations like
-`Start_Element`, `End_Element`, ...
+`Start_Element`, `End_Element`…
 
 Note the activation of the `Schema_Validation_Feature` feature, without which
 no validation takes place:

--- a/docs/unicode.rst
+++ b/docs/unicode.rst
@@ -53,9 +53,9 @@ Several representations are possible, mostly depending on the exact font used
 at that time. A single glyph can correspond to a sequence of characters, or a
 single character to a sequence of glyphs.
 
-The Unicode standard doesn't deal with glyphs, although a suggested
+The Unicode standard doesn’t deal with glyphs, although a suggested
 representation is given for each character in the standard. Likewise, this
-module doesn't provide any graphical support for Unicode, and will just deal
+module doesn’t provide any graphical support for Unicode, and will just deal
 with textual memory representation and encodings.
 
 Take a look at the **GtkAda** library that provides the graphical interface for
@@ -85,7 +85,7 @@ a portable manner.
 
 Given its size, most applications will only support a subset of Unicode.  Some
 of the scripts, most notably Arabic and Asian languages, require a special
-support in the application (right-to-left writing,...), and thus will not be
+support in the application (right-to-left writing…), and thus will not be
 supported by some applications.
 
 The Unicode standard includes a set of internal catalogs, called collections.
@@ -119,7 +119,7 @@ contains 128 characters. A super-set of it is the ISO/8859-1 character set.
 Another character set is the JIS X 0208, used to encode Japanese characters.
 
 Note that a character set is different from a repertoire. For instance, the
-same character C with cedilla doesn't have the same integer value in the
+same character C with cedilla doesn’t have the same integer value in the
 ISO/8859-1 character set and the ISO/8859-2 character set.
 
 Unicode is also such a character set, that contains all the possible characters
@@ -129,7 +129,7 @@ that it also specifies algorithms for rendering presentation forms of some
 scripts (say Arabic), handling of bi-directional texts that mix for instance
 Latin and Hebrew, algorithms for sorting and string comparison, and much more.
 
-Currently, our Unicode package doesn't include any support for these
+Currently, our Unicode package doesn’t include any support for these
 algorithms.
 
 Unicode and ISO 10646 define formally a 31-bit character set. However, of this
@@ -197,7 +197,7 @@ computer architecture.
 There exists a number of possible encoding schemes. Some of them encode all
 integers on the same number of bytes. They are called fixed-width encoding
 forms, and include the standard encoding for Internet emails (**7bits**, but it
-can't encode all characters), as well as the simple **8bits** scheme, or the
+can’t encode all characters), as well as the simple **8bits** scheme, or the
 **EBCDIC** scheme. Among them is also the **UTF-32** scheme which is defined in
 the Unicode standard.
 
@@ -205,7 +205,7 @@ Another set of encoding schemes encode integers on a variable number of bytes.
 These include two schemes that are also defined in the Unicode standard, namely
 **Utf-8** and **Utf-16**.
 
-Unicode doesn't impose any specific encoding. However, it is most often
+Unicode doesn’t impose any specific encoding. However, it is most often
 associated with one of the Utf encodings. They each have their own properties
 and advantages:
 
@@ -293,10 +293,10 @@ single type, `Unicode.Encodings.Unicode_Encoding`.
 
 This package provides additional functions to manipulate these encodings, for
 instance to retrieve them by the common name that is associated with them (for
-instance "utf-8", "iso-8859-15",...), since very often the encoding scheme is
+instance ``utf-8``, ``iso-8859-15``…), since very often the encoding scheme is
 implicit. If you are speaking of utf-8 string, most people always assume you
 also use the unicode character set. Likewise, if you are speaking of
-"iso-8859-1", most people will assume you string is encoded as 8 byte
+``iso-8859-1``, most people will assume you string is encoded as 8 byte
 characters.
 
 The goal of the `Unicode.Encodings` package is to make these implicit

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -6,7 +6,7 @@ Using the library
 
 XML/Ada is a library. When compiling an application that uses it, you
 thus need to declare this dependency. The default installation implies the
-use of GNAT project files. See the GPRbuild and GPR Companion Tools User's
+use of GNAT project files. See the GPRbuild and GPR Companion Tools User’s
 Guide for more information on the project files and
 how to create them for your application.
 
@@ -34,9 +34,9 @@ and you build your application with::
 Note in the project file the first line, which indicates that your
 application requires XML/Ada to build. This will automatically set the
 appropriate compiler and linker switches to use XML/Ada. Your application
-will be linked against all modules of XML/Ada (DOM, SAX, ...).
+will be linked against all modules of XML/Ada (DOM, SAX…).
 
-If your application doesn't use DOM, you can replace the first line with
+If your application doesn’t use DOM, you can replace the first line with
 something like::
 
   with "xmlada_sax";
@@ -46,7 +46,7 @@ linked with.
 
 If the installation prefix is the same as your GNAT installation (which is
 the case of the preinstalled version of the library), then GPRbuild will
-automatically find XML/Ada's project files. If XML/Ada is not installed into
+automatically find XML/Ada’s project files. If XML/Ada is not installed into
 a predefined location (e.g. because you rebuilt it from sources), you need to
 let GPRbuild know where to find the project files. This is done by setting the
 `GPR_PROJECT_PATH` environment variable, by adding to it the directory that
@@ -78,7 +78,7 @@ Running on VxWorks
 
 On VxWorks, XML Ada processing might require more stack space than what is
 typically available from the VxWorks shell, the tasks spawned from there with
-"sp", or Ada tasks with no or a too small Storage_Size value attached.
+``sp``, or Ada tasks with no or a too small Storage_Size value attached.
 
 Such stack overflow conditions are typically characterized by non-deterministic
 erratic behavior and can be cured by allocating more stack space for the tasks


### PR DESCRIPTION
Sphinx fixes such errors, or does not depending on the current locale,
preventing reproducible builds.